### PR TITLE
Fix TypeError for pickling cv2.KeyPoint objects

### DIFF
--- a/brick_detector.py
+++ b/brick_detector.py
@@ -21,29 +21,54 @@ MIN_CONTOUR_AREA = 500
 orb = cv2.ORB_create(nfeatures=N_FEATURES_PER_IMAGE)
 bf_matcher = cv2.BFMatcher(cv2.NORM_HAMMING, crossCheck=False)
 
+def _keypoints_to_tuples(keypoints):
+    if keypoints is None:
+        return []
+    return [(kp.pt, kp.size, kp.angle, kp.response, kp.octave, kp.class_id) for kp in keypoints]
+
+def _tuples_to_keypoints(kp_tuples):
+    if kp_tuples is None:
+        return []
+    return [cv2.KeyPoint(x=t[0][0], y=t[0][1], _size=t[1], _angle=t[2],
+                         _response=t[3], _octave=t[4], _class_id=t[5]) for t in kp_tuples]
+
 def get_reference_descriptors():
     """
-    Loads or computes and saves keypoints, descriptors, and shapes for all reference brick images.
-    The saved data will be a list of tuples: (filename, descriptors, keypoints, shape).
+    Loads or computes and saves keypoints (in a pickleable format), descriptors,
+    and shapes for all reference brick images.
+    The saved data in .pkl file is a list of tuples:
+    (filename, descriptors, list_of_keypoint_tuples, shape).
+    The function returns a list of tuples with live KeyPoint objects:
+    (filename, descriptors, list_of_cv2.KeyPoint_objects, shape).
     Shape is (height, width).
     """
     if os.path.exists(DESCRIPTORS_FILE):
         try:
             with open(DESCRIPTORS_FILE, 'rb') as f:
-                data = pickle.load(f)
-                if isinstance(data, list) and data and \
-                   isinstance(data[0], tuple) and len(data[0]) == 4 and \
-                   (not data[0][2] or (isinstance(data[0][2], list) and (not data[0][2] or hasattr(data[0][2][0], 'pt')))) and \
-                   isinstance(data[0][3], tuple) and len(data[0][3]) == 2: # check keypoints is a list
-                    print("Loaded reference data (des, kp, shape) from cache.")
-                    return data
-                else:
-                    print("Cached descriptors file is in an old format or invalid. Recomputing with new structure.")
-        except Exception as e: # More generic catch for any unpickling or validation issue
-            print(f"Error loading or validating cached descriptors: {e}. Recomputing with new structure.")
+                pickled_data = pickle.load(f)
 
-    print("Computing reference descriptors, keypoints, and shapes...")
-    reference_data_list = []
+            # Validate structure: list of (filename, descriptors, list_of_kp_tuples, shape)
+            if isinstance(pickled_data, list) and pickled_data and \
+               isinstance(pickled_data[0], tuple) and len(pickled_data[0]) == 4 and \
+               isinstance(pickled_data[0][1], np.ndarray) and \
+               isinstance(pickled_data[0][2], list) and \
+               (not pickled_data[0][2] or (isinstance(pickled_data[0][2][0], tuple) and len(pickled_data[0][2][0]) == 6)) and \
+               isinstance(pickled_data[0][3], tuple) and len(pickled_data[0][3]) == 2:
+
+                reconstructed_data_for_runtime = []
+                for filename, des, kp_tuples, shape_val in pickled_data:
+                    reconstructed_kps = _tuples_to_keypoints(kp_tuples)
+                    reconstructed_data_for_runtime.append((filename, des, reconstructed_kps, shape_val))
+                print("Loaded and reconstructed reference data (des, kp, shape) from cache.")
+                return reconstructed_data_for_runtime
+            else:
+                print("Cached descriptors file is in an old/invalid format. Recomputing.")
+        except Exception as e:
+            print(f"Error loading or validating cached descriptors: {e}. Recomputing.")
+
+    print("Computing reference descriptors, keypoints (pickleable), and shapes...")
+    reference_data_to_pickle = [] # This will store data with keypoints as tuples
+
     if not os.path.exists(REFERENCE_IMAGE_DIR):
         print(f"Error: Reference image directory not found at {REFERENCE_IMAGE_DIR}")
         return []
@@ -63,25 +88,34 @@ def get_reference_descriptors():
             continue
         print(f"  Image {filename} read successfully. Shape: {img.shape}")
 
-        keypoints, descriptors = orb.detectAndCompute(img, None)
+        keypoints, descriptors = orb.detectAndCompute(img, None) # These are live KeyPoint objects
         print(f"  ORB feature computation done for {filename}.")
 
         if descriptors is not None and len(descriptors) > 0:
-            img_shape = img.shape[:2] # (height, width)
-            reference_data_list.append((filename, descriptors, keypoints, img_shape))
+            img_shape = img.shape[:2]
+            pickleable_kps = _keypoints_to_tuples(keypoints) # Convert live KPs to tuples for pickling
+            reference_data_to_pickle.append((filename, descriptors, pickleable_kps, img_shape))
             print(f"  Found {len(descriptors)} descriptors and {len(keypoints)} keypoints for {filename}. Shape: {img_shape}")
         else:
             print(f"  Warning: No descriptors found for reference image {filename}.")
 
-    print(f"Finished processing all reference images. Total data entries collected: {len(reference_data_list)}.")
-    if not reference_data_list:
-        print("No valid reference data (des, kp, shape) was collected.")
+    print(f"Finished processing all reference images. Total data entries collected: {len(reference_data_to_pickle)}.")
+    if not reference_data_to_pickle:
+        print("No valid reference data was collected.")
+        return [] # Return empty list if nothing was processed
 
-    print(f"Attempting to save {len(reference_data_list)} reference data entries to {DESCRIPTORS_FILE}...")
+    print(f"Attempting to save {len(reference_data_to_pickle)} reference data entries to {DESCRIPTORS_FILE}...")
     with open(DESCRIPTORS_FILE, 'wb') as f:
-        pickle.dump(reference_data_list, f)
-    print(f"Saved {len(reference_data_list)} reference data entries to {DESCRIPTORS_FILE}.")
-    return reference_data_list
+        pickle.dump(reference_data_to_pickle, f) # Save the pickleable version
+    print(f"Saved {len(reference_data_to_pickle)} reference data entries to {DESCRIPTORS_FILE}.")
+
+    # For immediate runtime use after computation, convert the just-computed pickleable KPs back to live KPs.
+    reconstructed_data_for_runtime = []
+    for fname, des, kp_tuples, shape_val in reference_data_to_pickle:
+        reconstructed_kps = _tuples_to_keypoints(kp_tuples)
+        reconstructed_data_for_runtime.append((fname, des, reconstructed_kps, shape_val))
+    return reconstructed_data_for_runtime
+
 
 REFERENCE_DESCRIPTORS = get_reference_descriptors()
 
@@ -98,7 +132,7 @@ def detect_brick(query_image_path):
         tuple | None: (cX, cY) for the centroid, or None.
         str: Orientation status ("head-on", "sideways", "angled", "unknown").
     """
-    if not REFERENCE_DESCRIPTORS:
+    if not REFERENCE_DESCRIPTORS: # This now contains live KeyPoint objects
         return False, "Error: No reference data loaded.", None, None, "unknown"
 
     query_img_bgr = cv2.imread(query_image_path)
@@ -107,7 +141,7 @@ def detect_brick(query_image_path):
 
     query_img_gray = cv2.cvtColor(query_img_bgr, cv2.COLOR_BGR2GRAY)
     query_img_hsv = cv2.cvtColor(query_img_bgr, cv2.COLOR_BGR2HSV)
-    query_img_height, query_img_width = query_img_gray.shape[:2]
+    # query_img_height, query_img_width = query_img_gray.shape[:2] # Not directly used yet
 
     bounding_box_final = None
     centroid_final = None
@@ -115,7 +149,7 @@ def detect_brick(query_image_path):
     detected_status_final = False
     status_messages = []
 
-    potential_detections = [] # List to store dicts of potential matches
+    potential_detections = []
 
     # 1. Color Segmentation
     green_mask = cv2.inRange(query_img_hsv, LOWER_GREEN, UPPER_GREEN)
@@ -124,15 +158,14 @@ def detect_brick(query_image_path):
     green_mask_morphed = cv2.dilate(green_mask_morphed, kernel, iterations = 2)
     contours, _ = cv2.findContours(green_mask_morphed, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
 
-    # 2. Process significant contours for feature matching
     significant_contours_found = False
     if contours:
         sorted_contours = sorted(contours, key=cv2.contourArea, reverse=True)
         for contour_idx, contour in enumerate(sorted_contours):
             if cv2.contourArea(contour) < MIN_CONTOUR_AREA:
-                if not significant_contours_found and contour_idx == 0: # Only log for the largest if it's too small
+                if not significant_contours_found and contour_idx == 0:
                     status_messages.append(f"Largest green region (Area: {cv2.contourArea(contour):.0f}) is below min area {MIN_CONTOUR_AREA}.")
-                break # Since sorted, no need to check smaller ones
+                break
             significant_contours_found = True
 
             contour_mask_for_features = np.zeros_like(query_img_gray)
@@ -141,7 +174,7 @@ def detect_brick(query_image_path):
 
             query_kp_contour, query_des_contour = orb.detectAndCompute(masked_query_img_gray, None)
 
-            if query_des_contour is None or len(query_des_contour) < MIN_MATCH_COUNT / 2: # Looser threshold for features within contour
+            if query_des_contour is None or len(query_des_contour) < MIN_MATCH_COUNT / 2:
                 status_messages.append(f"Contour {contour_idx} (Area {cv2.contourArea(contour):.0f}): Few features ({len(query_des_contour if query_des_contour is not None else [])}).")
                 continue
 
@@ -149,28 +182,26 @@ def detect_brick(query_image_path):
 
             best_match_for_this_contour = {'score': -1, 'data': None}
 
-            for ref_filename, ref_des, ref_kp, ref_shape in REFERENCE_DESCRIPTORS:
-                if ref_des is None or not ref_kp : continue
+            for ref_filename, ref_des, ref_kp_live, ref_shape in REFERENCE_DESCRIPTORS: # ref_kp_live are KeyPoint objects
+                if ref_des is None or not ref_kp_live : continue
                 matches = bf_matcher.knnMatch(query_des_contour, ref_des, k=2)
 
-                # Ensure matches are valid before trying to access matches[0]
                 if not matches or not matches[0] or len(matches[0]) < 2:
-                    # status_messages.append(f"  Skipping {ref_filename} for contour due to insufficient match candidates.")
                     continue
                 good_matches = [m for m, n in matches if m.distance < MATCHER_THRESHOLD * n.distance]
 
                 if len(good_matches) >= MIN_MATCH_COUNT and len(good_matches) > best_match_for_this_contour['score']:
                     best_match_for_this_contour['score'] = len(good_matches)
-                    best_match_for_this_contour['data'] = (ref_filename, good_matches, query_kp_contour, ref_kp, ref_shape)
+                    best_match_for_this_contour['data'] = (ref_filename, good_matches, query_kp_contour, ref_kp_live, ref_shape)
 
             if best_match_for_this_contour['data']:
-                ref_filename, good_matches, q_kp, r_kp, r_shape = best_match_for_this_contour['data']
+                ref_filename, good_matches, q_kp, r_kp_live, r_shape = best_match_for_this_contour['data']
                 status_messages.append(f"  Best match in contour: {ref_filename} ({len(good_matches)} matches).")
 
-                src_pts = np.float32([r_kp[m.trainIdx].pt for m in good_matches]).reshape(-1, 1, 2)
+                src_pts = np.float32([r_kp_live[m.trainIdx].pt for m in good_matches]).reshape(-1, 1, 2)
                 dst_pts = np.float32([q_kp[m.queryIdx].pt for m in good_matches]).reshape(-1, 1, 2)
 
-                if len(src_pts) >= 4 and len(dst_pts) >=4: # findHomography needs at least 4 points
+                if len(src_pts) >= 4 and len(dst_pts) >=4:
                     M_homography, _ = cv2.findHomography(src_pts, dst_pts, cv2.RANSAC, 5.0)
                     if M_homography is not None:
                         h_ref, w_ref = r_shape
@@ -181,7 +212,7 @@ def detect_brick(query_image_path):
                         cx = int(moments["m10"]/moments["m00"]) if moments["m00"]!=0 else 0
                         cy = int(moments["m01"]/moments["m00"]) if moments["m00"]!=0 else 0
                         potential_detections.append({'score':len(good_matches), 'status_detail':f"Homography match in contour with {ref_filename}", 'bounding_box':bbox, 'centroid':(cx,cy)})
-                    else: # Homography failed, use contour bounding rectangle
+                    else:
                         x_br, y_br, w_br, h_br = cv2.boundingRect(contour)
                         bbox = [[x_br,y_br],[x_br+w_br,y_br],[x_br+w_br,y_br+h_br],[x_br,y_br+h_br]]
                         moments = cv2.moments(contour)
@@ -191,35 +222,32 @@ def detect_brick(query_image_path):
                 else:
                     status_messages.append(f"  Not enough points for homography with {ref_filename} (need >=4, got {len(src_pts)}).")
 
-
-    # 3. Fallback to whole image feature matching if no confident contour detections
     if not potential_detections:
         status_messages.append("No confident feature match in contours. Trying whole image.")
         query_kp_whole, query_des_whole = orb.detectAndCompute(query_img_gray, None)
 
-        if query_des_whole is None or len(query_des_whole) < MIN_MATCH_COUNT:
+        if query_des_whole is None or len(query_des_whole) < MIN_MATCH_COUNT :
             status_messages.append(f"Not enough features in whole query image ({len(query_des_whole if query_des_whole is not None else [])}).")
         else:
             status_messages.append(f"Whole image ({len(query_kp_whole)} features):")
             best_match_for_whole = {'score': -1, 'data': None}
 
-            for ref_filename, ref_des, ref_kp, ref_shape in REFERENCE_DESCRIPTORS:
-                if ref_des is None or not ref_kp: continue
+            for ref_filename, ref_des, ref_kp_live, ref_shape in REFERENCE_DESCRIPTORS: # ref_kp_live are KeyPoint objects
+                if ref_des is None or not ref_kp_live: continue
                 matches = bf_matcher.knnMatch(query_des_whole, ref_des, k=2)
 
                 if not matches or not matches[0] or len(matches[0]) < 2:
-                    # status_messages.append(f"  Skipping {ref_filename} for whole image due to insufficient match candidates.")
                     continue
                 good_matches = [m for m,n in matches if m.distance < MATCHER_THRESHOLD * n.distance]
 
                 if len(good_matches) >= MIN_MATCH_COUNT and len(good_matches) > best_match_for_whole['score']:
                     best_match_for_whole['score'] = len(good_matches)
-                    best_match_for_whole['data'] = (ref_filename, good_matches, query_kp_whole, ref_kp, ref_shape)
+                    best_match_for_whole['data'] = (ref_filename, good_matches, query_kp_whole, ref_kp_live, ref_shape)
 
             if best_match_for_whole['data']:
-                ref_filename, good_matches, q_kp, r_kp, r_shape = best_match_for_whole['data']
+                ref_filename, good_matches, q_kp, r_kp_live, r_shape = best_match_for_whole['data']
                 status_messages.append(f"  Best whole image match: {ref_filename} ({len(good_matches)} matches).")
-                src_pts = np.float32([r_kp[m.trainIdx].pt for m in good_matches]).reshape(-1,1,2)
+                src_pts = np.float32([r_kp_live[m.trainIdx].pt for m in good_matches]).reshape(-1,1,2)
                 dst_pts = np.float32([q_kp[m.queryIdx].pt for m in good_matches]).reshape(-1,1,2)
 
                 if len(src_pts) >= 4 and len(dst_pts) >=4:
@@ -233,9 +261,8 @@ def detect_brick(query_image_path):
                         cx = int(moments["m10"]/moments["m00"]) if moments["m00"]!=0 else 0
                         cy = int(moments["m01"]/moments["m00"]) if moments["m00"]!=0 else 0
                         potential_detections.append({'score':len(good_matches), 'status_detail':f"Homography match on WHOLE IMAGE with {ref_filename}", 'bounding_box':bbox, 'centroid':(cx,cy)})
-                    else: # Homography failed for whole image
+                    else:
                          status_messages.append(f"  Whole image homography failed with {ref_filename}.")
-                         # Optional: Fallback to bounding box of matched keypoints if homography fails
                          points_for_bbox = np.float32([ q_kp[m.queryIdx].pt for m in good_matches ])
                          x_br_kp, y_br_kp, w_br_kp, h_br_kp = cv2.boundingRect(points_for_bbox)
                          bbox = [[x_br_kp,y_br_kp],[x_br_kp+w_br_kp,y_br_kp],[x_br_kp+w_br_kp,y_br_kp+h_br_kp],[x_br_kp,y_br_kp+h_br_kp]]
@@ -245,64 +272,42 @@ def detect_brick(query_image_path):
                 else:
                      status_messages.append(f"  Not enough points for whole image homography with {ref_filename} (need >=4, got {len(src_pts)}).")
 
-
-    # 4. Final Decision based on potential_detections
     if potential_detections:
         best_detection = sorted(potential_detections, key=lambda x: x['score'], reverse=True)[0]
         detected_status_final = True
-        status_messages.insert(0, best_detection['status_detail']) # Prepend best status
+        status_messages.insert(0, best_detection['status_detail'])
         bounding_box_final = best_detection['bounding_box']
         centroid_final = best_detection['centroid']
 
-        # --- Orientation Detection (Step 8) ---
         if bounding_box_final:
-            # For a perspective transform, dst_corners gives 4 points.
-            # We need width and height. For a non-rectangular quadrilateral,
-            # we can use minAreaRect or approximate from the perspective corners.
-            # Simpler: use cv2.boundingRect on the perspective corners for an upright width/height.
-            # Or, if it's already a simple [x,y,w,h] style box (from contour fallback), use that directly.
-
-            # Ensure bounding_box_final is a NumPy array of points for minAreaRect
             pts_for_orientation = np.array(bounding_box_final, dtype=np.int32)
-
-            # Get the minimum area rectangle which can be rotated
             rect = cv2.minAreaRect(pts_for_orientation)
-            # box_points = cv2.boxPoints(rect) # These are the 4 corners of the minAreaRect
-            # box_points = np.int0(box_points)
-
-            # (center (x,y), (width, height), angle of rotation)
             _, (w_rect, h_rect), _ = rect
 
             if w_rect == 0 or h_rect == 0:
                 orientation_final = "degenerate_bbox"
             else:
-                # Ensure width is always the larger dimension for consistent aspect ratio
                 actual_width = max(w_rect, h_rect)
                 actual_height = min(w_rect, h_rect)
-                aspect_ratio = actual_width / actual_height
+                aspect_ratio = actual_width / actual_height if actual_height > 0 else float('inf') # Avoid division by zero
 
-                # Define thresholds (these are heuristics and may need tuning)
-                # Assuming "sideways" means the long side is presented (wide aspect ratio)
-                # Assuming "head-on" means the short side is presented (narrower, more square/tall aspect ratio)
-                SIDEWAYS_THRESHOLD = 1.6  # e.g., if width is > 1.6 times height
-                HEAD_ON_THRESHOLD_MAX = 1.3 # e.g., if width is < 1.3 times height (closer to square or tall)
-                                          # This also implies height is the dominant visual dimension for "head-on"
+                SIDEWAYS_THRESHOLD = 1.6
+                HEAD_ON_THRESHOLD_MAX = 1.3
 
                 if aspect_ratio > SIDEWAYS_THRESHOLD:
                     orientation_final = "sideways"
-                elif aspect_ratio < HEAD_ON_THRESHOLD_MAX: # Closer to square or tall
+                elif aspect_ratio < HEAD_ON_THRESHOLD_MAX:
                     orientation_final = "head-on"
                 else:
                     orientation_final = "angled"
-            status_messages.append(f"Orientation based on aspect ratio ({aspect_ratio:.2f} from w:{w_rect:.0f},h:{h_rect:.0f}): {orientation_final}")
+            status_messages.append(f"Orientation ({aspect_ratio:.2f} from w:{w_rect:.0f},h:{h_rect:.0f}): {orientation_final}")
 
-    elif significant_contours_found : # Green found, but no feature match
+    elif significant_contours_found :
         status_messages.append("Significant green regions found, but no feature match to reference bricks.")
-    else: # No green, no features
+    else:
         status_messages.append("No brick detected (no significant green or feature matches).")
 
     final_status_message = " | ".join(status_messages)
-    # Ensure return types are consistent even if no detection
     return detected_status_final, final_status_message, bounding_box_final, centroid_final, orientation_final
 
 
@@ -321,17 +326,30 @@ if __name__ == '__main__':
     if REFERENCE_DESCRIPTORS and os.path.exists(REFERENCE_IMAGE_DIR):
         image_files = [f for f in os.listdir(REFERENCE_IMAGE_DIR) if f.lower().endswith(('.png', '.jpg', '.jpeg'))]
         if image_files:
+            # Test with a known brick image
             test_query_image_name = image_files[0]
             test_query_image_path = os.path.join(REFERENCE_IMAGE_DIR, test_query_image_name)
-
             print(f"\n--- Testing detect_brick with: {test_query_image_path} ---")
             detected, status, bbox, centroid, orientation = detect_brick(test_query_image_path)
             print(f"Detection result: {detected}")
             print(f"Status: {status}")
             print(f"Bounding Box: {bbox}")
             print(f"Centroid: {centroid}")
-            print(f"Orientation: {orientation}") # Will be 'unknown' for now
+            print(f"Orientation: {orientation}")
             print("--- Test detection finished ---")
+
+            # Test with a dummy non-brick image (e.g., black image)
+            dummy_black_img_path = "dummy_black_test.jpg"
+            cv2.imwrite(dummy_black_img_path, np.zeros((100,100,3), dtype=np.uint8))
+            print(f"\n--- Testing detect_brick with: {dummy_black_img_path} ---")
+            detected, status, bbox, centroid, orientation = detect_brick(dummy_black_img_path)
+            print(f"Detection result: {detected}")
+            print(f"Status: {status}")
+            print(f"Bounding Box: {bbox}")
+            print(f"Centroid: {centroid}")
+            print(f"Orientation: {orientation}")
+            print("--- Test detection finished ---")
+            os.remove(dummy_black_img_path)
         else:
             print("No images found in reference directory to run a test detection.")
     else:


### PR DESCRIPTION
- Modified `get_reference_descriptors` in `brick_detector.py` to correctly handle serialization and deserialization of `cv2.KeyPoint` objects.
- KeyPoints are converted to tuples of their attributes before pickling and reconstructed into KeyPoint objects upon loading.
- This resolves the `TypeError: cannot pickle 'cv2.KeyPoint' object` that occurred during the generation of the `reference_descriptors.pkl` cache file.
- Users will need to delete their existing `reference_descriptors.pkl` file to allow it to be regenerated with the correct format.